### PR TITLE
Fixes for Safari

### DIFF
--- a/etc/css/style.css
+++ b/etc/css/style.css
@@ -116,7 +116,6 @@ body {
   color: var(--primary-text);
   margin: 0px;
 
-  overflow-x: hidden;
 }
 
 input {

--- a/etc/index.html
+++ b/etc/index.html
@@ -83,7 +83,7 @@
     <script src="flecs_explorer_imports.js"></script>
 
     <!-- Dependencies -->
-    <script src="deps/vue.dev.js"></script>
+    <script src="deps/vue.min.js"></script>
     <script src="deps/Parser.js"></script>
     <script src="deps/SelectHelper.js"></script>
     <script src="deps/TextareaDecorator.js"></script>

--- a/etc/js/app.js
+++ b/etc/js/app.js
@@ -1,5 +1,5 @@
 
-Vue.config.devtools = true;
+Vue.config.devtools = false;
 
 // Track state of connection to remote app
 const ConnectionState = {

--- a/etc/js/components/icon.vue
+++ b/etc/js/components/icon.vue
@@ -76,6 +76,13 @@ module.exports = {
   stroke-width: 2;
   fill: none;
   overflow: visible;
+
+  /* Preempts SVG jitter bug in Safari */
+  -webkit-backface-visibility: hidden;
+  -webkit-perspective: 1000;
+  -webkit-font-smoothing: antialiased;
+  -webkit-transform-style: preserve-3d;
+  -webkit-transform: translateZ(0); 
 }
 
 .codicons {

--- a/etc/js/components/tooltip.vue
+++ b/etc/js/components/tooltip.vue
@@ -41,7 +41,6 @@ module.exports = {
         ],
       }).then(
         ({x,y}) => {
-          // console.log(x,y);
           Object.assign(this.$el.style, {
             left: `${x}px`,
             top: `${y}px`,
@@ -53,7 +52,6 @@ module.exports = {
   created() {
   },
   mounted() {
-    console.log("positioning");
     this.position();
     this.element.addEventListener("mouseenter", () => { this.show() });
     this.element.addEventListener("mouseleave", () => { this.hide() });

--- a/etc/js/components/tooltip.vue
+++ b/etc/js/components/tooltip.vue
@@ -24,6 +24,13 @@ module.exports = {
   },
   methods: {
     show() {
+      this.position();
+      this.show_state = true;
+    },
+    hide() {
+      this.show_state = false;
+    },
+    position() {
       let target = this.element;
       let tooltip = this.$el;
       FloatingUIDOM.computePosition(target, tooltip, {
@@ -40,16 +47,14 @@ module.exports = {
             top: `${y}px`,
           });
         }
-      )
-
-      this.show_state = true;
-
-    },
-    hide() {
-      this.show_state = false;
-    },
+      );
+    }
+  },
+  created() {
   },
   mounted() {
+    console.log("positioning");
+    this.position();
     this.element.addEventListener("mouseenter", () => { this.show() });
     this.element.addEventListener("mouseleave", () => { this.hide() });
     
@@ -79,8 +84,7 @@ module.exports = {
     visibility: hidden;
     opacity: 0;
     transform: translateY(2px);
-    transition: all 0.15s ease-out;
-
+    transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out;
   }
 
   .tooltip-visible {
@@ -89,7 +93,7 @@ module.exports = {
     visibility: visible;
     opacity: 1;
     transform: translateY(0px);
-    transition: all 0.15s 0.8s ease-in-out;
+    transition: opacity 0.15s 0.8s ease-in-out, transform 0.15s 0.8s ease-in-out;
   }
 
 </style>


### PR DESCRIPTION
1. Fix SVG jitter bug in Safari.

2. Fix issue where Safari sometimes positions tooltips outside of frame causing a weird horizontal overflow. 