### PR TITLE
Fix editing of enum values

### DIFF
--- a/etc/js/entity_inspector.js
+++ b/etc/js/entity_inspector.js
@@ -906,7 +906,7 @@ const inspector_component = Vue.component('inspector', {
       for (const component in this.edit_inputs) {
         const comp_input = this.edit_inputs[component];
         const comp_input_value = comp_input.value;
-        if (typeof comp_input_value === 'object') {
+        if (Object.getPrototypeOf(comp_input_value) === Object.prototype) {
           let comp_value = {};
           for (const key in comp_input_value) {
             const input = comp_input_value[key];


### PR DESCRIPTION
Currently the explorer will error if you attempt to modify the value of an enum (or anything else that doesn't have a key).
```
vue.min.js:6 TypeError: input.to_json is not a function
    at a.set_components (entity_inspector.js:913:37)
    at Be (vue.min.js:6:11394)
    at a.n (vue.min.js:6:13178)
    at Be (vue.min.js:6:11394)
    at e.$emit (vue.min.js:6:34446)
    at a.on_submit (entity_inspector.js:311:12)
    at Be (vue.min.js:6:11394)
    at a.n (vue.min.js:6:13178)
    at Be (vue.min.js:6:11394)
    at e.$emit (vue.min.js:6:34446)
```

This is because the previous code doing `typeof comp_input_value === 'object'` is also true when there is a single value rather than an object of key -> value.
This is because the "value" is passed as a Vue object for the input field which then has `.to_json()` called on it.

To fix this problem I adjusted the code to instead detect if the object has a prototype of a regular object `Object.getPrototypeOf(comp_input_value) === Object.prototype`.
If the the Vue object gets passed `Object.getPrototypeOf(comp_input_value)` returns a different prototype called "Cn" so will be false.


Tested using the following reproduction flecs app and then attempted to edit the singleton state of `GameState` via the explorer.
```c++
#include "flecs.h"

enum struct GameState {
    Init,
    MainMenu,
    Connect,
    InGame,
    Exit
};

int main(int argc, char** argv) {
    flecs::world ecs{ argc, argv };

    ecs.component<GameState>();

    ecs.set<GameState>(GameState::Init);

    return ecs.app()
        .enable_monitor()
        .enable_rest()
        .run();
}
```