### PR TITLE
Add :first for single value inspector-props and fix handling of is_array

### DIFF
--- a/etc/js/entity_inspector.js
+++ b/etc/js/entity_inspector.js
@@ -509,18 +509,19 @@ Vue.component('inspector-props', {
   },
   template: `
     <div :class="css">
-      <template v-if="is_object">
-        <template v-if="is_array">
-          <div class="inspector-prop" v-for="(v, k, i) in value"><template v-if="i && list">,&nbsp</template><inspector-kv :parent_prop="parent_prop" :type="prop_type(k)" ":value="v" :list="list" v-on="$listeners"/></div>
-        </template>
-        <template v-else>
-          <div class="inspector-prop" v-for="(v, k, i) in value"><inspector-kv :parent_prop="parent_prop" :prop_key="k" :type="prop_type(k)" :value="v" :list="list" :first="i == 0" v-on="$listeners"/></div>
-        </template>
+      <template v-if="is_array">
+        <div class="inspector-prop" v-for="(v, k, i) in value">
+          <inspector-kv :parent_prop="parent_prop" :type="prop_type(k)" ":value="v" :list="list" :first="i == 0" v-on="$listeners"/>
+        </div>
+      </template>
+      <template v-else-if="is_object">
+        <div class="inspector-prop" v-for="(v, k, i) in value">
+          <inspector-kv :parent_prop="parent_prop" :prop_key="k" :type="prop_type(k)" :value="v" :list="list" :first="i == 0" v-on="$listeners"/>
+        </div>
       </template>
       <template v-else>
         <div class="inspector-prop">
-          <inspector-kv :parent_prop="parent_prop" :type="type" :value="value" :list="list" 
-            v-on="$listeners"/>
+          <inspector-kv :parent_prop="parent_prop" :type="type" :value="value" :list="list" :first="true"  v-on="$listeners"/>
         </div>
       </template>
     </div>

--- a/etc/js/entity_inspector.js
+++ b/etc/js/entity_inspector.js
@@ -510,8 +510,8 @@ Vue.component('inspector-props', {
   template: `
     <div :class="css">
       <template v-if="is_array">
-        <div class="inspector-prop" v-for="(v, k, i) in value">
-          <inspector-kv :parent_prop="parent_prop" :type="prop_type(k)" ":value="v" :list="list" :first="i == 0" v-on="$listeners"/>
+        <div class="inspector-prop" v-for="(v, i) in value">
+          <inspector-kv :parent_prop="parent_prop" :type="type" :value="v" :list="list" :first="i == 0" v-on="$listeners"/>
         </div>
       </template>
       <template v-else-if="is_object">


### PR DESCRIPTION
Fixes the formatting of enum relations in query results.

**Before:**
![image](https://github.com/flecs-hub/explorer/assets/1109304/27bbfb05-4c10-4faf-a463-67730050ffc5)

**After:**
![image](https://github.com/flecs-hub/explorer/assets/1109304/481d64c2-b826-4dbe-8a95-b60f9d7238e8)

---

I also noticed that `<template v-if="is_array">` was never getting used because `<template v-if="is_object">` never gets executed for an array.
I swapped the templates to use `<template v-else-if="is_object">` so it correctly switches between the 3 cases of array, object and single value.

There was also another minor mistake with `v-for` which fixed the formatting of array types.
**Before:**
![image](https://github.com/flecs-hub/explorer/assets/1109304/22f4ffbf-2d37-47fb-a894-7c8e056c80e7)

**After:**
![image](https://github.com/flecs-hub/explorer/assets/1109304/ffc86ace-9ee6-416d-9d67-df62eaa4bf99)



Tested using the following reproduction flecs app and then attempted to edit the singleton state of `GameState` via the explorer.
```c++
#include "flecs.h"

enum struct GameState {
    Init,
    MainMenu,
    Connect,
    InGame,
    Exit
};

struct TestType {
    int test[3];
};

int main(int argc, char** argv) {
    flecs::world ecs{ argc, argv };

    ecs.component<GameState>();

    ecs.set<GameState>(GameState::Init);
    
    
    ecs.component<TestType>()
        .array<int>(3);
    
    ecs.entity("Test")
        .set<TestType>({ { 1, 2, 3 } });

    return ecs.app()
        .enable_monitor()
        .enable_rest()
        .run();
}
```