### PR TITLE
Move docs to the bottom of the menu bar.

### DIFF
--- a/etc/index.html
+++ b/etc/index.html
@@ -13,7 +13,7 @@
   <body spellcheck="false">
     <div id="app">
       <menu-bar
-        :items="['docs', 'entities', 'queries', 'stats', 'pipeline', 'commands', 'info']">
+        :items="['entities', 'queries', 'stats', 'pipeline', 'commands', 'info', 'docs']">
         <template v-slot:docs>
           <menu-button 
             name="docs" 


### PR DESCRIPTION
Having docs be first is confusing.  Generally link to docs and such at that are not actual app features go at the bottom of bars like this.