### PR TITLE
Fix indexOf parameters being swapped

### DIFF
--- a/etc/flecs.js
+++ b/etc/flecs.js
@@ -443,7 +443,7 @@ const flecs = {
                   }
 
                   let portIndex = url.indexOf(":"); // first is protocol
-                  portIndex = url.indexOf(portIndex + 1, ":");
+                  portIndex = url.indexOf(":", portIndex + 1);
                   if (portIndex == -1) {
                     url += ":27750";
                   }


### PR DESCRIPTION
Should be [`indexOf(searchString, position)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf). Fixes being unable to connect to a flecs server using a different port.