### PR TITLE
Fix escape '-' in parent names to prevent query errors

### DIFF
--- a/etc/js/components/widgets/tree/entity-subtree.vue
+++ b/etc/js/components/widgets/tree/entity-subtree.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="entity-subtree">
-    <entity-tree-item 
-      :conn="conn" 
-      :item="item" 
+    <entity-tree-item
+      :conn="conn"
+      :item="item"
       :depth="depth"
       :selectedItem="selectedItem"
       v-for="item in treeQueryResult"
@@ -58,15 +58,15 @@ function updateQuery() {
   }
 
   let q = `
-    [none] ?flecs.core.Module, 
+    [none] ?flecs.core.Module,
     [none] ?flecs.core.Component,
     [none] ?flecs.core.Relationship,
     [none] ?flecs.core.Trait,
     [none] ?flecs.core.Target,
     [none] ?flecs.core.Query,
-    [none] ?flecs.core.Prefab, 
-    [none] ?flecs.core.Disabled, 
-    [none] ?flecs.core.ChildOf(_, $this), 
+    [none] ?flecs.core.Prefab,
+    [none] ?flecs.core.Disabled,
+    [none] ?flecs.core.ChildOf(_, $this),
     [none] ?flecs.core.IsA($this, $base|self)`
     ;
 
@@ -76,8 +76,8 @@ function updateQuery() {
   if (!nf && !qf) {
     let path = props.path;
     if (path) {
-      path = path.replaceAll(" ", "\\ ");
-      q += `, (flecs.core.ChildOf, ${path})`;
+      const escapedPath = path.replace(/([ ():\-])/g, '\\$1');
+      q += `, (flecs.core.ChildOf, ${escapedPath})`;
     }
   }
 
@@ -93,11 +93,11 @@ function updateQuery() {
     }
   }
 
-  treeQuery.value = 
+  treeQuery.value =
     props.conn.query(q, {
-      try: true, 
-      rows: true, 
-      limit: 1000, 
+      try: true,
+      rows: true,
+      limit: 1000,
       doc: true,
       managed: true,
       persist: props.path === "0" // persist root query across reconnects


### PR DESCRIPTION
This pull request includes a small update to the `updateQuery` function in `entity-subtree.vue`. The change ensures that hyphens in the `path` variable are properly escaped when constructing the query.

### Before fix
![before](https://github.com/user-attachments/assets/ee8e878f-9b18-46c9-b978-32d76b44dea0)

### After fix
![after](https://github.com/user-attachments/assets/7e1aa5b7-8ea2-4770-b2fe-df4c7bce777c)
