### PR TITLE
Remember toggle state for key-value component members in inspector

### DIFF
--- a/etc/js/components/widgets/inspector/entity-inspector-component.vue
+++ b/etc/js/components/widgets/inspector/entity-inspector-component.vue
@@ -70,6 +70,7 @@
     <template v-if="expand && value">
       <div class="component-value">
         <entity-inspector-value
+          :path="fullName"
           :value="value"
           :type="type"
           :readonly="isReadonly"

--- a/etc/js/components/widgets/inspector/entity-inspector-kv.vue
+++ b/etc/js/components/widgets/inspector/entity-inspector-kv.vue
@@ -18,6 +18,7 @@
       </entity-inspector-preview>
       <template v-if="expand">
         <entity-inspector-value
+          :path="path"
           :value="value"
           :type="type"
           :readonly="readonly"
@@ -44,6 +45,7 @@ export default { name: "entity-inspector-kv" }
 import { defineProps, defineEmits, ref, onMounted } from 'vue';
 
 const props = defineProps({
+  path: {type: String, required: true},
   keyname: {type: String, required: true},
   value: {required: true},
   type: {type: Object, required: true},
@@ -55,7 +57,7 @@ const expand = ref(false);
 
 function toggle() {
   expand.value = !expand.value;
-  localStorage.setItem(`${props.keyname}.expand`, String(expand.value));
+  localStorage.setItem(`${props.path}.expand`, String(expand.value));
 }
 
 function setValue(evt, key) {
@@ -67,7 +69,7 @@ function setValue(evt, key) {
 }
 
 onMounted(() => {
-  expand.value = localStorage.getItem(`${props.keyname}.expand`) === "true";
+  expand.value = localStorage.getItem(`${props.path}.expand`) === "true";
 });
 
 </script>

--- a/etc/js/components/widgets/inspector/entity-inspector-kv.vue
+++ b/etc/js/components/widgets/inspector/entity-inspector-kv.vue
@@ -41,7 +41,7 @@ export default { name: "entity-inspector-kv" }
 </script>
 
 <script setup>
-import { defineProps, defineEmits, ref } from 'vue';
+import { defineProps, defineEmits, ref, onMounted } from 'vue';
 
 const props = defineProps({
   keyname: {type: String, required: true},
@@ -55,6 +55,7 @@ const expand = ref(false);
 
 function toggle() {
   expand.value = !expand.value;
+  localStorage.setItem(`${props.keyname}.expand`, String(expand.value));
 }
 
 function setValue(evt, key) {
@@ -64,6 +65,10 @@ function setValue(evt, key) {
     emit('setValue', { key: key, value: evt.value });
   }
 }
+
+onMounted(() => {
+  expand.value = localStorage.getItem(`${props.keyname}.expand`) === "true";
+});
 
 </script>
 

--- a/etc/js/components/widgets/inspector/entity-inspector-value.vue
+++ b/etc/js/components/widgets/inspector/entity-inspector-value.vue
@@ -4,6 +4,7 @@
       <div class="prop-grid">
         <template v-for="(value, key) in value">
           <entity-inspector-kv
+            :path="path + '.' + key"
             :keyname="key"
             :value="value"
             :type="type[key]"
@@ -32,6 +33,7 @@ export default { name: "entity-inspector-value" }
 import { defineProps, defineEmits } from 'vue';
 
 const props = defineProps({
+  path: {type: String, required: true},
   value: {required: true},
   type: {type: Object, required: true},
   readonly: {type: Boolean, required: true}


### PR DESCRIPTION
# Issue:
Currently inspector doesn't remember whether key-value members of components were expanded or not:
![flecs-inspector-remember-kv-issue](https://github.com/user-attachments/assets/571c1ce1-f19f-4a2a-bc67-117fcf184c74)

# Solution:
This commit adds this behavior in the same way as [3d63b6b](https://github.com/flecs-hub/explorer/commit/3d63b6bb716838ad834d5749af19df661c53ab21):
![flecs-inspector-remember-kv-resolution](https://github.com/user-attachments/assets/d8280975-b7fe-4a92-b36e-040f7c93c9f2)
