### PR TITLE
Remove entityQueryResult undefining on query change to fix inspector flicker

### DIFF
--- a/etc/js/components/widgets/inspector/entity-inspector-container.vue
+++ b/etc/js/components/widgets/inspector/entity-inspector-container.vue
@@ -113,7 +113,7 @@ const entityBrief = computed(() => {
 });
 
 const entityName = computed(() => {
-  if (props.entityQueryResult) {
+  if (props.entityQueryResult && props.entityQueryResult.name !== undefined) {
     return props.entityQueryResult.name;
   } else {
     return explorer.shortenEntity(props.path)

--- a/etc/js/components/widgets/inspector/entity-inspector.vue
+++ b/etc/js/components/widgets/inspector/entity-inspector.vue
@@ -294,7 +294,6 @@ function updateQuery() {
 
   if (lastQuery) {
     lastQuery.abort();
-    entityQueryResult.value = undefined;
   }
 
   if (props.path) {

--- a/etc/js/components/widgets/inspector/entity-inspector.vue
+++ b/etc/js/components/widgets/inspector/entity-inspector.vue
@@ -409,6 +409,7 @@ function updateQuery() {
         }, 
         (err) => {
           loading.value = true;
+          entityQueryResult.value = undefined;
         }, 
         (request) => {
           loading.value = true;

--- a/etc/js/components/widgets/inspector/entity-inspector.vue
+++ b/etc/js/components/widgets/inspector/entity-inspector.vue
@@ -294,6 +294,9 @@ function updateQuery() {
 
   if (lastQuery) {
     lastQuery.abort();
+    if (entityQueryResult.value && entityQueryResult.value.name) {
+      entityQueryResult.value.name = undefined;
+    }
   }
 
   if (props.path) {


### PR DESCRIPTION
# Issue:
The inspector flickers whenever you select a different entity:
![flecs-inspector-flicker-issue](https://github.com/user-attachments/assets/3525d72e-7ec1-400f-8167-932461c75a09)

# Solution:
Remove setting entityQueryResult to undefined as next entity fetch occurs, as doing this just leaves the view with nothing to show while we wait for the next query.

This makes for a nicer user experience, if a user is attempting to compare values between entities, or generally doesn't want the inspect scroll bar reset to the top.

![flecs-inspector-flicker-resolution](https://github.com/user-attachments/assets/35433a49-76c9-46b0-8ca4-8fe29a5951a8)


